### PR TITLE
Remove what I think was an old debug statement

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -71,7 +71,6 @@ func (p *prompt) Prompt(windowID string) (<-chan *dbus.Variant, error) {
 		var res []interface{}
 
 		for s := range sig {
-			fmt.Println(s.Path)
 			if s.Path == p.path {
 				res = s.Body
 				break

--- a/prompt.go
+++ b/prompt.go
@@ -4,7 +4,6 @@
 package keyring
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/godbus/dbus/v5"


### PR DESCRIPTION
I've been enjoying this package for a while, but kept wondering why I was seeing a random path printed out. I decided to fix it for a specific repo. Now I am experiencing it again. So I thought I'd contribute this back.

This PR removes the printing of the path while prompting during an unlock.